### PR TITLE
Update README.md: missing subject field

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Options:
 Parameter         | Description
 :---------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 to                | Email address of the recipient(s). Example: "Bob <bob@host.com>". You can use commas to separate multiple recipients. Make sure to include all To, Cc and Bcc recipients of the message.
+subject           | Subject of the message.
 html              | HTML version of the message.
 text              | Text version of the message.
 message           | MIME string of the message. Make sure to use multipart/form-data to send this as a file upload.


### PR DESCRIPTION
The subject field was missing in the list of supported fields of the messages.create API call, even though the example shows it.