### PR TITLE
Update variable declarations to use proper keywords

### DIFF
--- a/examples/addresses.js
+++ b/examples/addresses.js
@@ -1,7 +1,7 @@
 // require('babel/register'); // uncomment this for node versions < 4
 
-var mailgun = require('../index');
-var mg = mailgun.client({
+const mailgun = require('../index');
+const mg = mailgun.client({
   username: 'api',
   key:  process.env.MAILGUN_API_KEY || '',
   public_key: process.env.MAILGUN_PUBLIC_KEY || ''

--- a/examples/list-domains.js
+++ b/examples/list-domains.js
@@ -1,7 +1,7 @@
 // require('babel/register'); // uncomment this for node versions < 4
 
-var mailgun = require('../index');
-var mg = mailgun.client({username: 'api', key:  process.env.MAILGUN_API_KEY || ''});
+const mailgun = require('../index');
+const mg = mailgun.client({username: 'api', key:  process.env.MAILGUN_API_KEY || ''});
 
 mg.domains.list()
   .then(domains => console.log(domains))

--- a/examples/send-email.js
+++ b/examples/send-email.js
@@ -1,15 +1,15 @@
 // require('babel/register'); // uncomment this for node versions < 4
 
-var fs = require('fs');
-var mailgun = require('../index');
-var mg = mailgun.client({username: 'api', key:  process.env.MAILGUN_API_KEY || ''});
+const fs = require('fs');
+const mailgun = require('../index');
+const mg = mailgun.client({username: 'api', key:  process.env.MAILGUN_API_KEY || ''});
 
-var domain = 'sandbox-123.mailgun.com';
-var fromEmail = 'Excited User <mailgun@sandbox-123.mailgun.com>';
-var toEmails = ['you@example.com']
+const domain = 'sandbox-123.mailgun.com';
+const fromEmail = 'Excited User <mailgun@sandbox-123.mailgun.com>';
+const toEmails = ['you@example.com']
 
-var mailgunLogo = fs.createReadStream(__dirname + '/mailgun.png');
-var rackspaceLogo = fs.createReadStream(__dirname + '/rackspace.png');
+const mailgunLogo = fs.createReadStream(__dirname + '/mailgun.png');
+const rackspaceLogo = fs.createReadStream(__dirname + '/rackspace.png');
 
 mg.messages.create(domain, {
     from: fromEmail,

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,19 +1,19 @@
 'use strict';
 
-var merge = require('lodash.merge');
-var defaults = require('lodash.defaults');
+const merge = require('lodash.merge');
+const defaults = require('lodash.defaults');
 
-var Request = require('./request');
+const Request = require('./request');
 
-var DomainClient = require('./domains');
-var EventClient = require('./events');
-var StatsClient = require('./stats');
-var SuppressionClient = require('./suppressions');
-var WebhookClient = require('./webhooks');
-var MessagesClient = require('./messages');
-var RoutesClient = require('./routes');
-var ValidateClient = require('./validate');
-var ParseClient = require('./parse');
+const DomainClient = require('./domains');
+const EventClient = require('./events');
+const StatsClient = require('./stats');
+const SuppressionClient = require('./suppressions');
+const WebhookClient = require('./webhooks');
+const MessagesClient = require('./messages');
+const RoutesClient = require('./routes');
+const ValidateClient = require('./validate');
+const ParseClient = require('./parse');
 
 class Client {
   constructor(options) {

--- a/lib/domains.js
+++ b/lib/domains.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var map = require('lodash.map');
-var urljoin = require('url-join');
+const map = require('lodash.map');
+const urljoin = require('url-join');
 
 class Domain {
   constructor(data, receiving, sending) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var map = require('lodash.map');
-var last = require('lodash.last');
-var indexBy = require('lodash.indexby');
-var urljoin = require('url-join');
+const map = require('lodash.map');
+const last = require('lodash.last');
+const indexBy = require('lodash.indexby');
+const urljoin = require('url-join');
 
 class EventClient {
   constructor(request) {
@@ -19,7 +19,7 @@ class EventClient {
   }
 
   _parsePageLinks(response) {
-    var pages;
+    let pages;
 
     pages = {};
     pages = map(response.body.paging, (url, id) => this._parsePage(id, url));
@@ -35,7 +35,7 @@ class EventClient {
   }
 
   get(domain, query) {
-    var url;
+    let url;
 
     if (query && query.page) {
       url = urljoin('/v2', domain, 'events', query.page);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -6,7 +6,7 @@ class ParseClient {
   }
 
   get(addresses, enableDnsEspChecks) {
-    var query = {};
+    let query = {};
 
     if (Array.isArray(addresses)) {
       addresses = addresses.join(',');

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var merge = require('lodash.merge');
-var popsicle = require('popsicle');
-var status = require('popsicle-status');
-var btoa = require('btoa');
-var urljoin = require('url-join');
-var APIError = require('./error');
+const merge = require('lodash.merge');
+const popsicle = require('popsicle');
+const status = require('popsicle-status');
+const btoa = require('btoa');
+const urljoin = require('url-join');
+const APIError = require('./error');
 
 function parseResponse() {
   return function(req) {

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var map = require('lodash.map');
-var urljoin = require('url-join');
+const map = require('lodash.map');
+const urljoin = require('url-join');
 
 class Stats {
   constructor(data) {

--- a/lib/suppressions.js
+++ b/lib/suppressions.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var map = require('lodash.map');
-var indexBy = require('lodash.indexby');
-var partialRight = require('lodash.partialright');
-var url = require('url');
-var urljoin = require('url-join');
-var createOptions = {
+const map = require('lodash.map');
+const indexBy = require('lodash.indexby');
+const partialRight = require('lodash.partialright');
+const url = require('url');
+const urljoin = require('url-join');
+const createOptions = {
   headers: { 'Content-Type': 'application/json' }
 };
 
@@ -47,14 +47,14 @@ class SuppressionClient {
   }
 
   _parsePage(id, pageUrl) {
-    var parsedUrl = url.parse(pageUrl, true);
-    var query = parsedUrl.query;
+    let parsedUrl = url.parse(pageUrl, true);
+    let query = parsedUrl.query;
 
     return { id: id, page: query.page, address: query.address, url: pageUrl };
   }
 
   _parsePageLinks(response) {
-    var pages;
+    let pages;
     pages = {};
     pages = map(response.body.paging, (url, id) => this._parsePage(id, url));
 
@@ -62,7 +62,7 @@ class SuppressionClient {
   }
 
   _parseList(response, Model) {
-    var data = {};
+    let data = {};
 
     data.items = map(response.body.items, data => new Model(data));
 
@@ -76,14 +76,13 @@ class SuppressionClient {
   }
 
   list(domain, type, query) {
-    var parser;
-    var model = this.models[type];
+    let model = this.models[type];
 
     return this.request.get(urljoin('v3', domain, type), query).then(response => this._parseList(response, model));
   }
 
   get(domain, type, address) {
-    var model = this.models[type];
+    let model = this.models[type];
     var parser = partialRight(this._parseItem, model);
     address = encodeURIComponent(address);
 

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var map = require('lodash.map');
 var urljoin = require('url-join');
 
 class Webhook {

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var map = require('lodash.map');
 var urljoin = require('url-join');
 
 class Webhook {


### PR DESCRIPTION
Add constants instead of vars for the variables that are not being redeclared.
Add lets instead of vars for the variables that are not used outside immediate enclosing blocks.