### PR TITLE
Add support for optional property of timeout

### DIFF
--- a/examples/send-email.js
+++ b/examples/send-email.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const mailgun = require('../index');
 
-const mg = mailgun.client({ username: 'api', key: process.env.MAILGUN_API_KEY || '' });
+const mg = mailgun.client({ username: 'api', key: process.env.MAILGUN_API_KEY || '', timeout: 60000 });
 
 const domain = 'sandbox-123.mailgun.com';
 const fromEmail = 'Excited User <mailgun@sandbox-123.mailgun.com>';

--- a/lib/interfaces/Options.ts
+++ b/lib/interfaces/Options.ts
@@ -3,4 +3,5 @@ export default interface Options {
   key: string;
   url?: string;
   public_key?: string;
+  timeout?: number;
 }

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -38,6 +38,7 @@ class Request {
   private username;
   private key;
   private url;
+  private timeout;
   private headers: any;
   private formData: new () => FormData;
 
@@ -45,6 +46,7 @@ class Request {
     this.username = options.username;
     this.key = options.key;
     this.url = options.url;
+    this.timeout = options.timeout;
     this.headers = options.headers || {};
     this.formData = formData;
   }
@@ -77,6 +79,7 @@ class Request {
         method: method.toLocaleUpperCase(),
         headers,
         throwHttpErrors: false,
+        timeout: this.timeout,
         ...params
       }
     );

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -17,7 +17,7 @@ describe('Client', function () {
   let client: any;
 
   beforeEach(function () {
-    client = new Client({ username: 'username', key: 'key', public_key: 'key' }, formData);
+    client = new Client({ username: 'username', key: 'key', public_key: 'key', timeout: 10000 }, formData);
   });
 
   it('raises error when username is not provided', function () {

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -40,7 +40,8 @@ describe('Request', function () {
         username: 'api',
         key: 'key',
         url: 'https://api.mailgun.com',
-        headers: { 'X-CSRF-Token': 'protectme' }
+        headers: { 'X-CSRF-Token': 'protectme' },
+        timeout: 10000
       }, formData);
 
       const res = req.request('get', '/v2/some/resource1', {


### PR DESCRIPTION
### What does this PR do?

This PR add support of the optional option of `timeout` when creating the Mailgun client.

Example:

```js
const mailgun = mg.client({
    username: 'api',
    key: '123',
    timeout: 10000 // in milliseconds
  });
```

### Ok but why?

Two reasons really, the default timeout of 10000 set by [ky](https://www.npmjs.com/package/ky) is just simply not enough, I'd like for this to be a minute but in order to do this right now, I have to add the Keep Alive header... and also because the old mailgun module use to support this [property](https://www.npmjs.com/package/mailgun-js#options).

As more people start transitioning to the official mailgun module, there might be some options that they are dependent on that this module does not support. I think we can slowly start introducing some more of these properties, but for now this is just for the timeout support.

### How does this work?

This mailgun module uses ky to send http requests, per their docs, we can simply forward a timeout property, defined or not. 

https://www.npmjs.com/package/ky#timeout

If no value is passed (which is what's happening right now) it will default to 10000.

### Unit Tests

Unit tests have been updated to include the timeout property, all are still passing.

### Final Notes

If there's anything else this PR needs to be satisfactory, please let me know so that I may address it!
