### PR TITLE
fix: make sure no undefined values are used in the formData

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -162,7 +162,7 @@ class Request {
           data[key].forEach(function (item: any) {
             formData.append(key, item);
           });
-        } else {
+        } else if (data[key] != null) {
           formData.append(key, data[key]);
         }
       });


### PR DESCRIPTION
Right now if you add a `cc` or `bcc` key in the payload but have it empty, you will receive this error: 👇
```
cc parameter is not a valid address. please check documentation
```
To fix this we can simply prevent adding empty keys into the formData